### PR TITLE
Configure global keycloak and gateway values

### DIFF
--- a/env/values.yaml
+++ b/env/values.yaml
@@ -17,3 +17,9 @@ jenkins:
     Global:
       EnvVars:
         TILLER_NAMESPACE: kube-system
+        
+global:
+  keycloak:
+    url: "http://activiti-keycloak.jx-staging.35.228.195.195.nip.io/auth"
+  gateway:
+    host: "activiti-cloud-gateway.jx-staging.35.228.195.195.nip.io"


### PR DESCRIPTION
so that, we can expose and try using released activiti-cloud-example-chart in staging environment.