### PR TITLE
activiti-cloud-example-chart-modeling to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
-# - name: activiti-cloud-full-example
-#   repository: https://activiti.github.io/activiti-cloud-helm-charts/
-#   version: 0.0.107
+- name: activiti-cloud-example-chart-modeling
+  repository: https://activiti.github.io/activiti-cloud-helm-charts/
+  version: 0.0.2
 - alias: expose
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io


### PR DESCRIPTION
Promote activiti-cloud-example-chart-modeling to version 0.0.2